### PR TITLE
Update cl_luabee.lua

### DIFF
--- a/Addon/Luabee/lua/autorun/client/cl_luabee.lua
+++ b/Addon/Luabee/lua/autorun/client/cl_luabee.lua
@@ -1,4 +1,3 @@
-
 LUABEE.DragThink = function() end
 LUABEE.Config = {}
 LUABEE.ALL_CODE_BLOCKS = {}
@@ -503,68 +502,21 @@ hook.Add("Initialize", "LUABEE_INIT", function()
 	
 	print("--> LUABEE Initialized.")
 
-	function LUABEE.GetValidArgs(i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15,i16,i17,i18,i19,i20) --20 is max. 
-		if i1 then
-			if i2 then
-				if i3 then
-					if i4 then
-						if i5 then
-							if i6 then
-								if i7 then
-									if i8 then
-										if i9 then
-											if i10 then
-												if i11 then
-													if i12 then
-														if i13 then
-															if i14 then
-																if i15 then
-																	if i16 then
-																		if i17 then
-																			if i18 then
-																				if i19 then
-																					if i20 then
-																						return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15,i16,i17,i18,i19,i20
-																					end
-																					return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15,i16,i17,i18,i19
-																				end
-																				return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15,i16,i17,i18
-																			end
-																			return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15,i16,i17
-																		end
-																		return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15,i16
-																	end
-																	return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14,i15
-																end
-																return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13,i14
-															end
-															return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12,i13
-														end
-														return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11,i12
-													end
-													return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10,i11
-												end
-												return i1,i2,i3,i4,i5,i6,i7,i8,i9,i10
-											end
-											return i1,i2,i3,i4,i5,i6,i7,i8,i9
-										end
-										return i1,i2,i3,i4,i5,i6,i7,i8
-									end
-									return i1,i2,i3,i4,i5,i6,i7
-								end
-								return i1,i2,i3,i4,i5,i6
-							end
-							return i1,i2,i3,i4,i5
-						end
-						return i1,i2,i3,i4
-					end
-					return i1,i2,i3
-				end
-				return i1, i2
+	// Shortened, made iterable - Josh 'Acecool' Moser
+	// I'm unsure of your intention with this function, but I did a test and it performed identically for me with no limit of vars.
+	function LUABEE.GetValidArgs( ... )
+		local _args = { };
+		local _input = { ... };
+
+		for i = 1, #_input do
+			if ( _input[ i ] ) then
+				table.insert( _args, _input[ i ] );
+			else
+				break;
 			end
-			return i1
 		end
-		return
+
+		return unpack( _args );
 	end
 end)
 
@@ -605,37 +557,12 @@ function LUABEE.JumpToCallHook()
 	pnl:JumpToPoint(x+w/2,y+h/2,true)
 end
 
-function string.Safe(text)
-	text = string.Replace(text,".","_")
-	text = string.Replace(text,"*","_")
-	text = string.Replace(text,"?","_")
-	text = string.Replace(text,"&","_")
-	text = string.Replace(text,"^","_")
-	text = string.Replace(text,"%","_")
-	text = string.Replace(text,"$","_")
-	text = string.Replace(text,"/","_")
-	text = string.Replace(text,[[\]],"_")
-	text = string.Replace(text,":","_")
-	text = string.Replace(text,";","_")
-	text = string.Replace(text,"<","_")
-	text = string.Replace(text,">","_")
-	--text = string.Replace(text," ","_")
-	text = string.Replace(text,"'","_")
-	text = string.Replace(text,[["]],"_")
-	text = string.Replace(text,"{","_")
-	text = string.Replace(text,"}","_")
-	text = string.Replace(text,"[","_")
-	text = string.Replace(text,"]","_")
-	text = string.Replace(text,"+","_")
-	text = string.Replace(text,"-","_")
-	text = string.Replace(text,"#","_")
-	text = string.Replace(text,"@","_")
-	text = string.Replace(text,"!","_")
-	text = string.Replace(text,"|","_")
-	text = string.Replace(text,"`","_")
-	text = string.Replace(text,",","_")
-	text = string.Replace(text,"~","_")
-	return text
+// Shortened - Josh 'Acecool' Moser
+// http://www.lua.org/pil/20.2.html
+// Caps = Inverse, so W strips all NON alpha-numeric
+function string.Safe( text )
+	text = string.gsub( text, "%W", "_" ); // gsub returns :: text, replacementsDone - print( gsub ) == "text	0"
+	return text;
 end
 
 function LUABEE.RunServer(c)


### PR DESCRIPTION
UPDATED:
function LUABEE.GetValidArgs( ... )
I'm not sure of your purpose for GetValidArgs, I'm assuming you want it to go through arguments until it reaches a nil, or false and then cut off ANY REMAINING AS WELL. I recreated that with an iteration which is cleaner, shorter, and doesn't have a limit of input arguments.

function string.Safe( text )
I updated the string.Safe to be shorter, cleaner, while encompassing ALL potentially unsafe characters. I included the URL in the comments. %w matches all alphanumeric so a-zA-Z0-9, when you capitalize any in that list, it does the INVERSE, so it matches anything that is NOT the aforementioned pattern and replaces them with _. You could theoretically return the gsub without editing the variable to remove O( 3 ) which reduces to O( 1 ) but because string.gsub returns text, howManyReplacementsWereMadeAsANumber if you were to print( ), you would have a number hanging off on the side. I'm unsure of how you use this, so I didn't want to change your return. 

Hope this helps ( By the way, the functions were tested, but double check there are no syntax errors due to removing the pyramid ),
-Josh
